### PR TITLE
Allow UV to use cached image thumbnails

### DIFF
--- a/config/uv/uv-config.json
+++ b/config/uv/uv-config.json
@@ -1,3 +1,13 @@
 {
-  
+  "options": {
+  },
+  "modules": {
+    "contentLeftPanel": {
+      "options": {
+        "thumbsCacheInvalidation": {
+          "enabled": false
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
These changes require a `yarn install` (and potentially clearing the browser's cache) to take effect. 